### PR TITLE
Bug fix: renaming bottom nav

### DIFF
--- a/shelfmate/src/App.jsx
+++ b/shelfmate/src/App.jsx
@@ -22,9 +22,9 @@ export default function App() {
           <p>Favorites Page (Coming Soon)</p>
         </div>
       )}
-      {currentView === 'swipe' && (
+      {currentView === 'discover' && (
         <div className="flex-1 flex items-center justify-center">
-          <p>Swipe Page (Coming Soon)</p>
+          <p>Discover Page (Coming Soon)</p>
         </div>
       )}
       {currentView === 'profile' && (

--- a/shelfmate/src/components/BottomNav.jsx
+++ b/shelfmate/src/components/BottomNav.jsx
@@ -29,20 +29,21 @@ export default function BottomNav({ currentView, onNavigate }) {
       )
     },
     {
+      name: 'discover',
+      label: 'Discover',
+      icon: (isActive) => (
+        <svg className="w-7 h-7" fill="none" stroke="currentColor" strokeWidth={isActive ? 2.5 : 2} viewBox="0 0 24 24">
+          <circle cx="12" cy="12" r="9" strokeLinecap="round" strokeLinejoin="round" />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M16.24 7.76l-2.12 6.36-6.36 2.12 2.12-6.36 6.36-2.12z" fill={isActive ? 'currentColor' : 'none'} />
+        </svg>
+      )
+    },
+    {
       name: 'favorites',
       label: 'Favorites',
       icon: (isActive) => (
         <svg className="w-7 h-7" fill={isActive ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth={isActive ? 1.5 : 2} viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-        </svg>
-      )
-    },
-    {
-      name: 'swipe',
-      label: 'Bookmarks',
-      icon: (isActive) => (
-        <svg className="w-7 h-7" fill={isActive ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth={isActive ? 1.5 : 2} viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
         </svg>
       )
     },


### PR DESCRIPTION
Renaming the bottom nav to match new names (Swiping -> Discover, Bookmarks -> Favorites)
<img width="544" height="761" alt="Screenshot 2025-10-29 at 3 43 39 PM" src="https://github.com/user-attachments/assets/d462e996-4966-4327-8c52-9a147c9a1167" />
